### PR TITLE
Feat : 물물교환 게시글 작성, 삭제, 상세조회, 목록조회 기능 완료

### DIFF
--- a/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
+++ b/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
@@ -1,4 +1,52 @@
 package kosta.main.exchangeposts.controller;
 
+import kosta.main.exchangeposts.dto.ExchangePostDTO;
+import kosta.main.exchangeposts.entity.ExchangePost;
+import kosta.main.exchangeposts.service.ExchangePostsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/exchangePosts")
 public class ExchangePostsController {
+
+  private final ExchangePostsService exchangePostsService;
+
+  @Autowired
+  public ExchangePostsController(ExchangePostsService exchangePostsService) {
+    this.exchangePostsService = exchangePostsService;
+  }
+
+  @GetMapping// 정상동작 확인완료
+  public List<ExchangePost> getAllExchangePosts() {
+    return exchangePostsService.findAllExchangePosts();
+  }
+
+  @GetMapping("/{id}") // 정상동작 확인 완료
+  public ResponseEntity<ExchangePost> getExchangePostById(@PathVariable Integer id) {
+    return exchangePostsService.findExchangePostById(id)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  @PostMapping// 정상 동작 확인 완료
+  public ExchangePost createExchangePost(@RequestBody ExchangePostDTO exchangePostDTO) {
+    return exchangePostsService.createExchangePost(exchangePostDTO);
+  }
+//  @PutMapping("/{id}")
+//  public ResponseEntity<ExchangePost> updateExchangePost(@PathVariable Integer id, @RequestBody ExchangePostDTO exchangePostDTO) {
+//    return ResponseEntity.ok(exchangePostsService.updateExchangePost(id, exchangePostDTO));
+//  }
+
+  @DeleteMapping("/{id}") // 정상 동작 확인 완료
+  public ResponseEntity<?> deleteExchangePost(@PathVariable Integer id) {
+    return exchangePostsService.findExchangePostById(id)
+        .map(exchangePost -> {
+          exchangePostsService.deleteExchangePost(id);
+          return ResponseEntity.ok().build();
+        })
+        .orElse(ResponseEntity.notFound().build());
+  }
 }

--- a/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
+++ b/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
@@ -24,29 +24,34 @@ public class ExchangePostsController {
     return exchangePostsService.findAllExchangePosts();
   }
 
-  @GetMapping("/{id}") // 정상동작 확인 완료
+  @GetMapping("/{id}")
   public ResponseEntity<ExchangePost> getExchangePostById(@PathVariable Integer id) {
-    return exchangePostsService.findExchangePostById(id)
-        .map(ResponseEntity::ok)
-        .orElse(ResponseEntity.notFound().build());
+    ExchangePost exchangePost = exchangePostsService.findExchangePostById(id);
+    if (exchangePost == null) {
+      return ResponseEntity.notFound().build();
+    }
+    return ResponseEntity.ok(exchangePost);
   }
+
 
   @PostMapping// 정상 동작 확인 완료
   public ExchangePost createExchangePost(@RequestBody ExchangePostDTO exchangePostDTO) {
     return exchangePostsService.createExchangePost(exchangePostDTO);
   }
+
 //  @PutMapping("/{id}")
 //  public ResponseEntity<ExchangePost> updateExchangePost(@PathVariable Integer id, @RequestBody ExchangePostDTO exchangePostDTO) {
 //    return ResponseEntity.ok(exchangePostsService.updateExchangePost(id, exchangePostDTO));
 //  }
 
-  @DeleteMapping("/{id}") // 정상 동작 확인 완료
+  @DeleteMapping("/{id}") // status를 변경하는 방식으로 수정예정
   public ResponseEntity<?> deleteExchangePost(@PathVariable Integer id) {
-    return exchangePostsService.findExchangePostById(id)
-        .map(exchangePost -> {
-          exchangePostsService.deleteExchangePost(id);
-          return ResponseEntity.ok().build();
-        })
-        .orElse(ResponseEntity.notFound().build());
+    ExchangePost exchangePost = exchangePostsService.findExchangePostById(id);
+    if (exchangePost == null) {
+      return ResponseEntity.notFound().build();
+    }
+    exchangePostsService.deleteExchangePost(id);
+    return ResponseEntity.ok().build();
   }
+
 }

--- a/src/main/java/kosta/main/exchangeposts/dto/ExchangePostDTO.java
+++ b/src/main/java/kosta/main/exchangeposts/dto/ExchangePostDTO.java
@@ -1,0 +1,40 @@
+package kosta.main.exchangeposts.dto;
+
+import kosta.main.exchangeposts.entity.ExchangePost.ExchangePostStatus;
+
+public class ExchangePostDTO {
+  private String title;
+  private String preferItems;
+  private String address;
+  private String content;
+  private Integer userId;
+  private Integer itemId;
+  private ExchangePostStatus exchangePostStatus;
+
+  // 게터와 세터
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getPreferItems() {
+    return preferItems;
+  }
+  public String getAddress() {
+    return address;
+  }
+  public String getContent() {
+    return content;
+  }
+  public Integer getUserId() {
+    return userId;
+  }
+  public Integer getItemId() {
+    return itemId;
+  }
+
+  public ExchangePostStatus getExchangePostStatus() {
+    return exchangePostStatus;
+  }
+
+}

--- a/src/main/java/kosta/main/exchangeposts/dto/ExchangePostDTO.java
+++ b/src/main/java/kosta/main/exchangeposts/dto/ExchangePostDTO.java
@@ -1,7 +1,9 @@
 package kosta.main.exchangeposts.dto;
 
 import kosta.main.exchangeposts.entity.ExchangePost.ExchangePostStatus;
+import lombok.Getter;
 
+@Getter
 public class ExchangePostDTO {
   private String title;
   private String preferItems;
@@ -10,31 +12,4 @@ public class ExchangePostDTO {
   private Integer userId;
   private Integer itemId;
   private ExchangePostStatus exchangePostStatus;
-
-  // 게터와 세터
-
-  public String getTitle() {
-    return title;
-  }
-
-  public String getPreferItems() {
-    return preferItems;
-  }
-  public String getAddress() {
-    return address;
-  }
-  public String getContent() {
-    return content;
-  }
-  public Integer getUserId() {
-    return userId;
-  }
-  public Integer getItemId() {
-    return itemId;
-  }
-
-  public ExchangePostStatus getExchangePostStatus() {
-    return exchangePostStatus;
-  }
-
 }

--- a/src/main/java/kosta/main/exchangeposts/entity/ExchangePost.java
+++ b/src/main/java/kosta/main/exchangeposts/entity/ExchangePost.java
@@ -5,16 +5,13 @@ import kosta.main.audit.Auditable;
 import kosta.main.items.entity.Item;
 import kosta.main.users.entity.User;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "exchange_posts")
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 public class ExchangePost extends Auditable {
 
@@ -45,6 +42,17 @@ public class ExchangePost extends Auditable {
     @Column(length = 20, nullable = false)
     private ExchangePostStatus exchangePostStatus = ExchangePostStatus.EXCHANGING;
 
+    @Builder
+    public ExchangePost(Integer exchangePostId, User user, Item item, String title, String preferItems, String address, String content, ExchangePostStatus exchangePostStatus) {
+        this.exchangePostId = exchangePostId;
+        this.user = user;
+        this.item = item;
+        this.title = title;
+        this.preferItems = preferItems;
+        this.address = address;
+        this.content = content;
+        this.exchangePostStatus = exchangePostStatus;
+    }
 
     public enum ExchangePostStatus {
         EXCHANGING , RESERVATION, COMPLETED, DELETED

--- a/src/main/java/kosta/main/exchangeposts/repository/ExchangePostsRepository.java
+++ b/src/main/java/kosta/main/exchangeposts/repository/ExchangePostsRepository.java
@@ -1,4 +1,10 @@
 package kosta.main.exchangeposts.repository;
 
-public interface ExchangePostsRepository {
+import kosta.main.exchangeposts.entity.ExchangePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExchangePostsRepository extends JpaRepository<ExchangePost, Integer> {
+
 }

--- a/src/main/java/kosta/main/exchangeposts/service/ExchangePostsService.java
+++ b/src/main/java/kosta/main/exchangeposts/service/ExchangePostsService.java
@@ -1,4 +1,71 @@
 package kosta.main.exchangeposts.service;
 
+import kosta.main.exchangeposts.dto.ExchangePostDTO;
+import kosta.main.exchangeposts.entity.ExchangePost;
+import kosta.main.exchangeposts.repository.ExchangePostsRepository;
+import kosta.main.items.entity.Item;
+import kosta.main.items.repository.ItemsRepository;
+import kosta.main.users.entity.User;
+import kosta.main.users.repository.UsersRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
 public class ExchangePostsService {
+
+  private final ExchangePostsRepository exchangePostRepository;
+  private final UsersRepository usersRepository;
+  private final ItemsRepository itemsRepository;
+
+  @Autowired
+  public ExchangePostsService(ExchangePostsRepository exchangePostRepository, UsersRepository usersRepository, ItemsRepository itemsRepository) {
+    this.exchangePostRepository = exchangePostRepository;
+    this.usersRepository = usersRepository;
+    this.itemsRepository = itemsRepository;
+  }
+  public ExchangePost createExchangePost(ExchangePostDTO exchangePostDTO) {
+    User user = usersRepository.findById(exchangePostDTO.getUserId())
+        .orElseThrow(() -> new RuntimeException("User not found"));
+    Item item = itemsRepository.findById(exchangePostDTO.getItemId())
+        .orElseThrow(() -> new RuntimeException("Item not found"));
+
+    ExchangePost exchangePost = ExchangePost.builder()
+        .user(user)
+        .item(item)
+        .title(exchangePostDTO.getTitle())
+        .preferItems(exchangePostDTO.getPreferItems())
+        .address(exchangePostDTO.getAddress())
+        .content(exchangePostDTO.getContent())
+        .exchangePostStatus(exchangePostDTO.getExchangePostStatus())
+        .build();
+
+    return exchangePostRepository.save(exchangePost);
+  }
+
+  public List<ExchangePost> findAllExchangePosts() {
+    return exchangePostRepository.findAll();
+  }
+
+  public Optional<ExchangePost> findExchangePostById(Integer id) {
+    return exchangePostRepository.findById(id);
+  }
+
+//  public ExchangePost updateExchangePost(Integer id, ExchangePostDTO exchangePostDTO) {
+//    return exchangePostRepository.findById(id).map(existingPost -> {
+//      // 필요한 경우, User와 Item 객체도 업데이트
+//      existingPost.setTitle(exchangePostDTO.getTitle());
+//      existingPost.setPreferItems(exchangePostDTO.getPreferItems());
+//      existingPost.setAddress(exchangePostDTO.getAddress());
+//      existingPost.setContent(exchangePostDTO.getContent());
+//      existingPost.setExchangePostStatus(exchangePostDTO.getExchangePostStatus());
+//      return exchangePostRepository.save(existingPost);
+//    }).orElseThrow(() -> new RuntimeException("ExchangePost not found"));
+//  }
+
+  public void deleteExchangePost(Integer id) {
+    exchangePostRepository.deleteById(id);
+  }
 }

--- a/src/main/java/kosta/main/exchangeposts/service/ExchangePostsService.java
+++ b/src/main/java/kosta/main/exchangeposts/service/ExchangePostsService.java
@@ -7,25 +7,19 @@ import kosta.main.items.entity.Item;
 import kosta.main.items.repository.ItemsRepository;
 import kosta.main.users.entity.User;
 import kosta.main.users.repository.UsersRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
+@AllArgsConstructor
 public class ExchangePostsService {
 
   private final ExchangePostsRepository exchangePostRepository;
   private final UsersRepository usersRepository;
   private final ItemsRepository itemsRepository;
 
-  @Autowired
-  public ExchangePostsService(ExchangePostsRepository exchangePostRepository, UsersRepository usersRepository, ItemsRepository itemsRepository) {
-    this.exchangePostRepository = exchangePostRepository;
-    this.usersRepository = usersRepository;
-    this.itemsRepository = itemsRepository;
-  }
   public ExchangePost createExchangePost(ExchangePostDTO exchangePostDTO) {
     User user = usersRepository.findById(exchangePostDTO.getUserId())
         .orElseThrow(() -> new RuntimeException("User not found"));
@@ -49,9 +43,10 @@ public class ExchangePostsService {
     return exchangePostRepository.findAll();
   }
 
-  public Optional<ExchangePost> findExchangePostById(Integer id) {
-    return exchangePostRepository.findById(id);
+  public ExchangePost findExchangePostById(Integer id) { // 기존에 Optional로 처리하던 NUll을 수동으로 처리
+    return exchangePostRepository.findById(id).orElse(null); // or .orElseThrow(...)
   }
+
 
 //  public ExchangePost updateExchangePost(Integer id, ExchangePostDTO exchangePostDTO) {
 //    return exchangePostRepository.findById(id).map(existingPost -> {

--- a/src/main/java/kosta/main/items/repository/ItemsRepository.java
+++ b/src/main/java/kosta/main/items/repository/ItemsRepository.java
@@ -1,4 +1,9 @@
 package kosta.main.items.repository;
 
-public interface ItemsRepository {
+import kosta.main.items.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ItemsRepository extends JpaRepository<Item, Integer> {
 }

--- a/src/main/java/kosta/main/users/repository/UsersRepository.java
+++ b/src/main/java/kosta/main/users/repository/UsersRepository.java
@@ -1,4 +1,9 @@
 package kosta.main.users.repository;
 
-public interface UsersRepository {
+import kosta.main.users.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UsersRepository extends JpaRepository<User, Integer> {
 }


### PR DESCRIPTION
물물교환 게시글 작성, 삭제, 상세조회, 목록조회 기능 완료하였습니다.
우선 유저 검증이나 이런건 고려하지 않고 간단하게 CRD 만 작성하였습니다.

또 관계 때문에 ItemsRepository, UsersRepository가 필요해서 우선 적으로 생성해뒀습니다.
