### PR TITLE
Feat : 물물교환 게시글 수정 기능 구현, 물물교환 게시글 삭제 기능 수정(Softdelete)

### DIFF
--- a/src/main/java/kosta/main/communityposts/entity/CommunityPost.java
+++ b/src/main/java/kosta/main/communityposts/entity/CommunityPost.java
@@ -32,7 +32,7 @@ public class CommunityPost extends Auditable {
     private String content;
 
     @Column
-    private Integer view;
+    private Integer views;
 
     @Column(length = 20, nullable = false)
     private CommunityPostStatus communityPostStatus = CommunityPostStatus.PUBLIC;

--- a/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
+++ b/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/exchangePosts")
+@RequestMapping("/api/exchange-posts")
 public class ExchangePostsController {
 
   private final ExchangePostsService exchangePostsService;
@@ -24,7 +24,7 @@ public class ExchangePostsController {
     return exchangePostsService.findAllExchangePosts();
   }
 
-  @GetMapping("/{id}")
+  @GetMapping("/{exchangePostId}")
   public ResponseEntity<ExchangePost> getExchangePostById(@PathVariable Integer id) {
     ExchangePost exchangePost = exchangePostsService.findExchangePostById(id);
     if (exchangePost == null) {
@@ -32,26 +32,29 @@ public class ExchangePostsController {
     }
     return ResponseEntity.ok(exchangePost);
   }
+  @PutMapping("/{exchangePostId}") // setter를 사용하지 않고 생성자를 활용하는 방식으로 수정
+  public ResponseEntity<ExchangePost> updateExchangePost(@PathVariable Integer exchangePostId, @RequestBody ExchangePostDTO exchangePostDTO) {
+    try {
+      ExchangePost updatedPost = exchangePostsService.updateExchangePost(exchangePostId, exchangePostDTO);
+      return ResponseEntity.ok(updatedPost);
+    } catch (RuntimeException e) {
+      return ResponseEntity.notFound().build();
+    }
+  }
+  @DeleteMapping("/{exchangePostId}") // softdelete로 수정 완료
+  public ResponseEntity<ExchangePost> deleteExchangePost(@PathVariable Integer exchangePostId, @RequestBody ExchangePostDTO exchangePostDTO) {
+    try {
+      ExchangePost updatedPost = exchangePostsService.updateExchangePost(exchangePostId, exchangePostDTO);
+      return ResponseEntity.ok(updatedPost);
+    } catch (RuntimeException e) {
+      return ResponseEntity.notFound().build();
+    }
+  }
 
 
   @PostMapping// 정상 동작 확인 완료
   public ExchangePost createExchangePost(@RequestBody ExchangePostDTO exchangePostDTO) {
     return exchangePostsService.createExchangePost(exchangePostDTO);
-  }
-
-//  @PutMapping("/{id}")
-//  public ResponseEntity<ExchangePost> updateExchangePost(@PathVariable Integer id, @RequestBody ExchangePostDTO exchangePostDTO) {
-//    return ResponseEntity.ok(exchangePostsService.updateExchangePost(id, exchangePostDTO));
-//  }
-
-  @DeleteMapping("/{id}") // status를 변경하는 방식으로 수정예정
-  public ResponseEntity<?> deleteExchangePost(@PathVariable Integer id) {
-    ExchangePost exchangePost = exchangePostsService.findExchangePostById(id);
-    if (exchangePost == null) {
-      return ResponseEntity.notFound().build();
-    }
-    exchangePostsService.deleteExchangePost(id);
-    return ResponseEntity.ok().build();
   }
 
 }

--- a/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
+++ b/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
@@ -4,6 +4,7 @@ import kosta.main.exchangeposts.dto.ExchangePostDTO;
 import kosta.main.exchangeposts.entity.ExchangePost;
 import kosta.main.exchangeposts.service.ExchangePostsService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -24,34 +25,23 @@ public class ExchangePostsController {
     return exchangePostsService.findAllExchangePosts();
   }
 
-  @GetMapping("/{exchangePostId}")
-  public ResponseEntity<ExchangePost> getExchangePostById(@PathVariable Integer id) {
-    ExchangePost exchangePost = exchangePostsService.findExchangePostById(id);
-    if (exchangePost == null) {
-      return ResponseEntity.notFound().build();
-    }
-    return ResponseEntity.ok(exchangePost);
+  @GetMapping("/{exchangePostId}") // 정상 동작 확인 완료
+  public ResponseEntity getExchangePostById(@PathVariable Integer exchangePostId) {
+    ExchangePost exchangePost = exchangePostsService.findExchangePostById(exchangePostId);
+    return new ResponseEntity(exchangePost, HttpStatus.OK);
+    // 23.11.23 exchangePostId와 같은값은 굳이 프론트로 노출시킬 이유가 없기 때문에 리팩터링때
+    // DTO를 개별적으로 생성한뒤 필요한 데이터만 보내기로 했다.
   }
-  @PutMapping("/{exchangePostId}") // setter를 사용하지 않고 생성자를 활용하는 방식으로 수정
+  @PutMapping("/{exchangePostId}") // 정상 동작 확인 완료
   public ResponseEntity<ExchangePost> updateExchangePost(@PathVariable Integer exchangePostId, @RequestBody ExchangePostDTO exchangePostDTO) {
-    try {
-      ExchangePost updatedPost = exchangePostsService.updateExchangePost(exchangePostId, exchangePostDTO);
-      return ResponseEntity.ok(updatedPost);
-    } catch (RuntimeException e) {
-      return ResponseEntity.notFound().build();
-    }
+    ExchangePost updatedPost = exchangePostsService.updateExchangePost(exchangePostId, exchangePostDTO);
+    return ResponseEntity.ok(updatedPost);
   }
-  @DeleteMapping("/{exchangePostId}") // softdelete로 수정 완료
+  @DeleteMapping("/{exchangePostId}") // softdelete로 수정 완료, 정상 동작 확인
   public ResponseEntity<ExchangePost> deleteExchangePost(@PathVariable Integer exchangePostId, @RequestBody ExchangePostDTO exchangePostDTO) {
-    try {
       ExchangePost updatedPost = exchangePostsService.updateExchangePost(exchangePostId, exchangePostDTO);
       return ResponseEntity.ok(updatedPost);
-    } catch (RuntimeException e) {
-      return ResponseEntity.notFound().build();
-    }
   }
-
-
   @PostMapping// 정상 동작 확인 완료
   public ExchangePost createExchangePost(@RequestBody ExchangePostDTO exchangePostDTO) {
     return exchangePostsService.createExchangePost(exchangePostDTO);

--- a/src/main/java/kosta/main/exchangeposts/dto/ExchangePostDTO.java
+++ b/src/main/java/kosta/main/exchangeposts/dto/ExchangePostDTO.java
@@ -1,5 +1,6 @@
 package kosta.main.exchangeposts.dto;
 
+import kosta.main.exchangeposts.entity.ExchangePost;
 import kosta.main.exchangeposts.entity.ExchangePost.ExchangePostStatus;
 import lombok.Getter;
 

--- a/src/main/java/kosta/main/exchangeposts/entity/ExchangePost.java
+++ b/src/main/java/kosta/main/exchangeposts/entity/ExchangePost.java
@@ -2,6 +2,7 @@ package kosta.main.exchangeposts.entity;
 
 import jakarta.persistence.*;
 import kosta.main.audit.Auditable;
+import kosta.main.exchangeposts.dto.ExchangePostDTO;
 import kosta.main.items.entity.Item;
 import kosta.main.users.entity.User;
 import lombok.AllArgsConstructor;
@@ -53,6 +54,28 @@ public class ExchangePost extends Auditable {
         this.content = content;
         this.exchangePostStatus = exchangePostStatus;
     }
+
+    public void updateExchangePost(Item item, String title, String preferItems, String address, String content, ExchangePostStatus exchangePostStatus) {
+        if (item != null) {
+            this.item = item;
+        }
+        if (title != null) {
+            this.title = title;
+        }
+        if (preferItems != null) {
+            this.preferItems = preferItems;
+        }
+        if (address != null) {
+            this.address = address;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+        if (exchangePostStatus != null) {
+            this.exchangePostStatus = exchangePostStatus;
+        }
+    }
+
 
     public enum ExchangePostStatus {
         EXCHANGING , RESERVATION, COMPLETED, DELETED

--- a/src/main/java/kosta/main/exchangeposts/service/ExchangePostsService.java
+++ b/src/main/java/kosta/main/exchangeposts/service/ExchangePostsService.java
@@ -43,24 +43,45 @@ public class ExchangePostsService {
     return exchangePostRepository.findAll();
   }
 
+  public ExchangePost updateExchangePost(Integer exchangePostId, ExchangePostDTO exchangePostDTO) {
+    ExchangePost existingPost = findExchangePostById(exchangePostId);
+
+    if (existingPost == null) {
+      throw new RuntimeException("ExchangePost not found");
+    }
+
+    // 기존 값들을 기본값으로 사용, 만약 값이 넘어온다면 넘어온값을 사용함
+    String title = exchangePostDTO.getTitle() != null ? exchangePostDTO.getTitle() : existingPost.getTitle();
+    String preferItems = exchangePostDTO.getPreferItems() != null ? exchangePostDTO.getPreferItems() : existingPost.getPreferItems();
+    String address = exchangePostDTO.getAddress() != null ? exchangePostDTO.getAddress() : existingPost.getAddress();
+    String content = exchangePostDTO.getContent() != null ? exchangePostDTO.getContent() : existingPost.getContent();
+    ExchangePost.ExchangePostStatus status = exchangePostDTO.getExchangePostStatus() != null ? exchangePostDTO.getExchangePostStatus() : existingPost.getExchangePostStatus();
+
+    // Item 객체 가져오기 (필요한 경우)
+    Item item = null;
+    if (exchangePostDTO.getItemId() != null) {
+      item = itemsRepository.findById(exchangePostDTO.getItemId())
+              .orElseThrow(() -> new RuntimeException("Item not found"));
+    } else {
+      item = existingPost.getItem(); // 기존 item 유지
+    }
+
+    // ExchangePost 업데이트
+    existingPost.updateExchangePost(
+            item,
+            title,
+            preferItems,
+            address,
+            content,
+            status
+    );
+
+    return exchangePostRepository.save(existingPost);
+  }
   public ExchangePost findExchangePostById(Integer id) { // 기존에 Optional로 처리하던 NUll을 수동으로 처리
     return exchangePostRepository.findById(id).orElse(null); // or .orElseThrow(...)
   }
 
 
-//  public ExchangePost updateExchangePost(Integer id, ExchangePostDTO exchangePostDTO) {
-//    return exchangePostRepository.findById(id).map(existingPost -> {
-//      // 필요한 경우, User와 Item 객체도 업데이트
-//      existingPost.setTitle(exchangePostDTO.getTitle());
-//      existingPost.setPreferItems(exchangePostDTO.getPreferItems());
-//      existingPost.setAddress(exchangePostDTO.getAddress());
-//      existingPost.setContent(exchangePostDTO.getContent());
-//      existingPost.setExchangePostStatus(exchangePostDTO.getExchangePostStatus());
-//      return exchangePostRepository.save(existingPost);
-//    }).orElseThrow(() -> new RuntimeException("ExchangePost not found"));
-//  }
 
-  public void deleteExchangePost(Integer id) {
-    exchangePostRepository.deleteById(id);
-  }
 }

--- a/src/main/java/kosta/main/exchangeposts/service/ExchangePostsService.java
+++ b/src/main/java/kosta/main/exchangeposts/service/ExchangePostsService.java
@@ -78,10 +78,9 @@ public class ExchangePostsService {
 
     return exchangePostRepository.save(existingPost);
   }
-  public ExchangePost findExchangePostById(Integer id) { // 기존에 Optional로 처리하던 NUll을 수동으로 처리
-    return exchangePostRepository.findById(id).orElse(null); // or .orElseThrow(...)
+  public ExchangePost findExchangePostById(Integer exchangePostId) { // 기존에 Optional로 처리하던 NUll을 수동으로 처리
+    return exchangePostRepository.findById(exchangePostId)
+            .orElseThrow(() -> new RuntimeException("물물교환게시글을 찾을 수 없습니다.")); // or .orElseThrow(...)
   }
-
-
 
 }


### PR DESCRIPTION
## 오전 구현 내용

### 물물교환 게시글 수정 기능 구현

```json
{
    "title": "Updated Title",
    "preferItems": "Updated Prefer Items",
    "address": "Updated Address",
    "content": "Updated content of the post.",
    "userId": 2,  // 수정할 게시물을 작성한 사용자의 ID
    "itemId": 2,  // 연관된 아이템의 ID
    "exchangePostStatus": "EXCHANGING"  // 게시물의 상태 (EXCHANGING, RESERVATION, COMPLETED, DELETED 중 하나)
}
```

- 이렇게 Postman으로 Json 객체를 날려 테스트 해보니 정상적으로 기능이 동작하였다.
- 기존에 Setter을 이용해서 수정 하던 방식은 Setter 메소드를 사용하면 값을 변경한 의도를 파악하기 힘들다는 점과 객체의 일관성을 유지하기 어렵다는 점을 고려하여 엔티티에 Update를 위한 생성자를 추가하는 방식으로 구현하였다.
    - 이때 보내주지 않은 컬럼에 대해서는 Null값으로 수정되는 오류가 있었으나 `String title = exchangePostDTO.getTitle() != null ? exchangePostDTO.getTitle() : existingPost.getTitle();` 이런 식으로 기존에 있던 값이 있다면 기존 값을 기본 값으로 만드는 방식으로 해결하였다.

### 물물교환 게시글 삭제 기능 수정(Soft delete)

```json
{
    "exchangePostStatus": "DELETED "  // 게시물의 상태 (EXCHANGING, RESERVATION, COMPLETED, DELETED 중 하나)
}
```

- 삭제된 데이터를 추후에 사용할 가능성이 있기도 하고 장기적으로 큰 데이터를 축적하지 않을거라 판단하여 Soft Delete 형태로 수정하기로하였다.
- 이렇게 기존에 사용하던 Update 로직에서 `exchangePostStatus` 만 데이터를 전송하면 논리 삭제가 가능하다.