### PR TITLE
Feat : 교환게시글 목록 조회 프론트와 데이터형태 동일하게 변경완료

### DIFF
--- a/src/main/java/kosta/main/bids/controller/BidController.java
+++ b/src/main/java/kosta/main/bids/controller/BidController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/exchange-posts")
@@ -18,8 +19,8 @@ public class BidController {
     private final BidService bidService;
 
     @PostMapping("/{exchangePostId}/bids")
-    public ResponseEntity<BidResponseDTO> createBid(@PathVariable("exchangePostId") Integer exchangePostId, @RequestBody BidsDto bidDTO) {
-        return ResponseEntity.ok(bidService.createBid(bidDTO));
+    public ResponseEntity<?> createBid(@RequestBody BidsDto bidDTO) {
+        return ResponseEntity.ok(Map.of("message", "Bid created successfully", "bidId", bidService.createBid(bidDTO)));
     }
 
     @GetMapping("/{exchangePostId}/bids")

--- a/src/main/java/kosta/main/bids/dto/BidListDTO.java
+++ b/src/main/java/kosta/main/bids/dto/BidListDTO.java
@@ -13,4 +13,10 @@ public class BidListDTO {
     private Integer exchangePostId; // 입찰 대상 게시글 ID
     private BidStatus status; // 입찰 상태
     private List<Integer> itemIds; // 입찰에 사용되는 아이템의 ID 목록
+    // 입찰하는 사용자의 Name
+    // 대표이미지 URL
+    // 입찰 ID
+    // item의 name을 ,로 나누고 String로 전송
+    //BidStatus가 delete인건 보내지 않기
+    //
 }

--- a/src/main/java/kosta/main/bids/repository/BidRepository.java
+++ b/src/main/java/kosta/main/bids/repository/BidRepository.java
@@ -3,6 +3,8 @@ package kosta.main.bids.repository;
 import kosta.main.bids.entity.Bid;
 import kosta.main.exchangeposts.entity.ExchangePost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,5 +12,9 @@ import java.util.List;
 @Repository
 public interface BidRepository extends JpaRepository<Bid, Integer> {
   List<Bid> findByExchangePost(ExchangePost exchangePost);
+
+  // ExchangePost에 해당하고 DELETED 상태가 아닌 Bid의 수를 카운트합니다.
+  @Query("SELECT COUNT(b) FROM Bid b WHERE b.exchangePost = :exchangePost AND b.status <> 3")
+  Integer countByExchangePostAndStatusNotDeleted(@Param("exchangePost") ExchangePost exchangePost);
 
 }

--- a/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
+++ b/src/main/java/kosta/main/exchangeposts/controller/ExchangePostsController.java
@@ -28,8 +28,7 @@ public class ExchangePostsController {
 
   @GetMapping("/{exchangePostId}")
   public ResponseEntity<ExchangePostDetailDTO> getExchangePostById(@PathVariable("exchangePostId") Integer exchangePostId) {
-    ExchangePostDetailDTO postDetail = exchangePostsService.findExchangePostById(exchangePostId);
-    return ResponseEntity.ok(postDetail);
+    return ResponseEntity.ok(exchangePostsService.findExchangePostById(exchangePostId));
   }
 
   @PutMapping("/{exchangePostId}") //필요한 데이터만 클라이언트 측으로 전송하도록 변경(23.11.27)

--- a/src/main/java/kosta/main/exchangeposts/dto/ExchangePostDetailDTO.java
+++ b/src/main/java/kosta/main/exchangeposts/dto/ExchangePostDetailDTO.java
@@ -16,4 +16,5 @@ public class ExchangePostDetailDTO {
   private final String address;
   private final String content;
   private final String exchangePostStatus;
+  // 추가해야할거 :  작성자의 item 내역, 거래희망 장소, title
 }

--- a/src/main/java/kosta/main/exchangeposts/dto/ExchangePostListDTO.java
+++ b/src/main/java/kosta/main/exchangeposts/dto/ExchangePostListDTO.java
@@ -7,14 +7,13 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-public class ExchangePostListDTO {
-  private final Integer exchangePostId;
-  private final Integer userId;
-  private final String userName;
-  private final Integer itemId;
-  private final String itemTitle;
-  private final String title;
-  private final String address;
-  private final String exchangePostStatus;
-  private final LocalDateTime created_at;
+public class ExchangePostListDTO { // 교환 게시글 전체 목록을 전송하는 DTO
+  private final Integer exchangePostId; // 교환 게시글 ID
+  private final String title; // 교환 게시글 제목
+  private final String preferItem; // 선호아이템
+  private final String address; // 거래 희망 주소
+  private final String exchangePostStatus; // 교환 게시글 상태(EXCHANGING , RESERVATION, COMPLETED, DELETED)
+  private final LocalDateTime created_at; // 교환 게시글 작성일
+  private final String imgUrl; // 교환 게시글에 등록된 item의 대표이미지 URㅣ
+  private final Integer bidCount; // 해당 교환 게시글에 등록된 입찰의 갯수를 세서 Integer 값으로 반환
 }

--- a/src/main/java/kosta/main/items/entity/Item.java
+++ b/src/main/java/kosta/main/items/entity/Item.java
@@ -57,6 +57,9 @@ public class Item extends Auditable {
     public void setIsBiding(IsBiding isBiding) {
         this.isBiding = isBiding;
     }
+    public void setBid(Bid bid) {
+        this.bid = bid;
+    }
 
     public void itemStatusUpdate(ItemStatus itemStatus) {
         this.itemStatus = itemStatus;

--- a/src/main/java/kosta/main/items/repository/ItemsRepository.java
+++ b/src/main/java/kosta/main/items/repository/ItemsRepository.java
@@ -2,7 +2,6 @@ package kosta.main.items.repository;
 
 import kosta.main.items.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 public interface ItemsRepository extends JpaRepository<Item,Integer> {
 


### PR DESCRIPTION
- **추후 구현 되어야 하는 내용** :
    - 교환 게시글 상세조회나, 입찰 상세조회를 진행할때 현재 ExchangePost를 작성한 userId를 비교해서 동일하다면 Post_owner 값을 true로 날려주는 로직이 필요하다. 현재는 **JWT**가 구현이 안되어있기 때문에 PathVariable로 임의의 값을 날려주고 비교하다가 나중에 JWT가 구현이 완료되면 JWT에서 Decode된 ID값과 작성자 비교 로직을 구현해야한다.
    - 프론트에서 원하는 형태로 데이터를 변경할 필요가 있다.
    -   **Image_URL 테이블**을 하나 더 만들어서 다시 구현하기로 String으로 Image_URL값만 꺼내서 LIst형태로 만들어서 프론트로 전송해주기
- **교환게시글 목록을 불러오는 API를 완성하였다.**
    - Softdelete를 사용하고 있어기에 삭제된 bid도 모두 bidCount에 포함되는 문제가 있어서 BidRepository에 쿼리를 추가해서 문제를 해결하였다.
        
        ```json
        @Query("SELECT COUNT(b) FROM Bid b WHERE b.exchangePost = :exchangePost AND b.status <> 3")
          Integer countByExchangePostAndStatusNotDeleted(@Param("exchangePost") ExchangePost exchangePost);
        ```
        
    - 응답 데이터
    (GET) http://localhost:8080/api/exchange-posts
        
        ```json
        [
            {
                "exchangePostId": 1,
                "title": "변경된 교환 게시글 제목",
                "preferItem": "변경된 원하는 아이템 리스트",
                "address": "변경된 게시글 주소",
                "exchangePostStatus": "EXCHANGING",
                "created_at": "2023-11-27T17:04:01.882961",
                "imgUrl": null,
                "bidCount": 2
            },
            {
                "exchangePostId": 2,
                "title": "변경된 교환 게시글 제목123123",
                "preferItem": "변경된 원하는 아이템 리스트123123",
                "address": "변경된 게시글 주소123123",
                "exchangePostStatus": "DELETED",
                "created_at": "2023-11-27T18:49:54.185331",
                "imgUrl": null,
                "bidCount": 0
            }
        ]
        ```